### PR TITLE
Add note about domain filtering not working with the tls upstream_addr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Putting it in a directory that is only readable by the super-user is not a bad i
 
 ## Filtering
 
-Domains can be filtered directly by the proxy, see the `[filtering]` section of the configuration file.
+Domains can be filtered directly by the proxy, see the `[filtering]` section of the configuration file. Note: Filtering only works with the DNSCrypt protocol and does not apply to DNS-over-HTTP (DoH) forwarding.
 
 ## Access control
 


### PR DESCRIPTION
I believe this observation is accurate.

Adding domains to the filter will filter them when using the DNSCrypt protocol, but forwarded DoH queries are _not_ filtered. One may have to re-think their architecture for filtering when wanting to use both DNSCrypt and DoH forwarding.