### PR TITLE
Update CI actions version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
       ARCHIVE_PATH: encrypted-dns_${{ github.ref_name }}_${{ matrix.target_alias }}${{ matrix.archive_suffix }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: goto-bus-stop/setup-zig@v2
 
-      - uses: hecrj/setup-rust-action@master
+      - uses: hecrj/setup-rust-action@v2
         with:
           rust-version: stable
           targets: ${{ matrix.target }}
@@ -63,12 +63,12 @@ jobs:
           cargo install cargo-deb
           cargo deb --output=encrypted-dns_${{ github.ref_name }}_amd64.deb --no-build
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: encrypted-dns_${{ matrix.target_alias }}
           path: ${{ env.ARCHIVE_PATH }}
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         with:
           name: encrypted-dns_deb-amd64
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@master
-      - uses: hecrj/setup-rust-action@master
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
         with:
           rust-version: nightly
       - name: Check Cargo availability


### PR DESCRIPTION
Fix lost release binaries, which is caused by `actions/upload-artifact` and `actions/download-artifact` versions mismatch.